### PR TITLE
[Feature] - Personal Account Expense Form Implementation

### DIFF
--- a/src/components/EditModal.tsx
+++ b/src/components/EditModal.tsx
@@ -2,7 +2,13 @@ import React, { useState, useEffect } from "react";
 import type { Transaction, Expense, DonationPayout } from "../types";
 
 import { X } from "lucide-react";
-import { DonationForm, ExpenseForm, TransactionForm } from "./Forms";
+import {
+  DonationForm,
+  ExpenseForm,
+  PersonalExpenseForm,
+  TransactionForm,
+} from "./Forms";
+import { useBusinessInfo } from "../hooks/useBusinessInfo";
 
 type EditableEntry = Transaction | Expense | DonationPayout;
 
@@ -25,6 +31,7 @@ export const EditModal: React.FC<EditModalProps> = ({
   ...props
 }) => {
   const [isAnimating, setIsAnimating] = useState(false);
+  const { isPersonalMode } = useBusinessInfo();
 
   useEffect(() => {
     if (isOpen) {
@@ -50,7 +57,13 @@ export const EditModal: React.FC<EditModalProps> = ({
           />
         );
       case "expense":
-        return (
+        return isPersonalMode ? (
+          <PersonalExpenseForm
+            mode="edit"
+            initialData={entry as Expense}
+            onSave={props.onUpdateExpense}
+          />
+        ) : (
           <ExpenseForm
             mode="edit"
             initialData={entry as Expense}

--- a/src/components/ExpenseHistory.tsx
+++ b/src/components/ExpenseHistory.tsx
@@ -6,6 +6,7 @@ import { ConfirmationModal } from "./common/ConfirmationModal";
 import { formatCurrency } from "../utils";
 import { usePartners } from "../hooks/usePartners";
 import { useConfirmation } from "../hooks/useConfirmation";
+import { useBusinessInfo } from "../hooks/useBusinessInfo";
 
 interface ExpenseHistoryProps {
   expenses: Expense[];
@@ -19,6 +20,7 @@ export const ExpenseHistory: React.FC<ExpenseHistoryProps> = ({
   onDelete,
 }) => {
   const { activePartners } = usePartners();
+  const { isPersonalMode } = useBusinessInfo();
   const [isExpanded, setIsExpanded] = useState(false);
   const { confirmation, showConfirmation, hideConfirmation } =
     useConfirmation();
@@ -83,12 +85,16 @@ export const ExpenseHistory: React.FC<ExpenseHistoryProps> = ({
                   >
                     Description
                   </th>
-                  <th scope="col" className={thClasses}>
-                    Type
-                  </th>
-                  <th scope="col" className={thClasses}>
-                    Spent By
-                  </th>
+                  {!isPersonalMode && (
+                    <th scope="col" className={thClasses}>
+                      Type
+                    </th>
+                  )}
+                  {!isPersonalMode && (
+                    <th scope="col" className={thClasses}>
+                      Spent By
+                    </th>
+                  )}
                   <th scope="col" className={`${thClasses} text-right`}>
                     Amount
                   </th>
@@ -112,6 +118,7 @@ export const ExpenseHistory: React.FC<ExpenseHistoryProps> = ({
                         {ex.description}
                       </div>
                       <div className="text-slate-500 dark:text-slate-400">
+                        {ex.category} •{" "}
                         {new Date(ex.date).toLocaleDateString("en-GB", {
                           day: "2-digit",
                           month: "short",
@@ -119,28 +126,32 @@ export const ExpenseHistory: React.FC<ExpenseHistoryProps> = ({
                         })}
                       </div>
                     </td>
-                    <td className="whitespace-nowrap px-3 py-4 text-sm text-slate-500">
-                      <span
-                        className={`inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${
-                          (ex.type || "personal") === "company"
-                            ? "bg-blue-50 text-blue-700 ring-blue-600/20 dark:bg-blue-900/50 dark:text-blue-300 dark:ring-blue-400/20"
-                            : "bg-slate-50 text-slate-700 ring-slate-600/20 dark:bg-slate-900/50 dark:text-slate-300 dark:ring-slate-400/20"
-                        }`}
-                      >
-                        {(ex.type || "personal") === "company"
-                          ? "Company"
-                          : "Personal"}
-                      </span>
-                    </td>
-                    <td className="whitespace-nowrap px-3 py-4 text-sm text-slate-500">
-                      <span
-                        className={`inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${getPartnerColor(
-                          ex.byWhom
-                        )}`}
-                      >
-                        {ex.byWhom}
-                      </span>
-                    </td>
+                    {!isPersonalMode && (
+                      <td className="whitespace-nowrap px-3 py-4 text-sm text-slate-500">
+                        <span
+                          className={`inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${
+                            (ex.type || "personal") === "company"
+                              ? "bg-blue-50 text-blue-700 ring-blue-600/20 dark:bg-blue-900/50 dark:text-blue-300 dark:ring-blue-400/20"
+                              : "bg-slate-50 text-slate-700 ring-slate-600/20 dark:bg-slate-900/50 dark:text-slate-300 dark:ring-slate-400/20"
+                          }`}
+                        >
+                          {(ex.type || "personal") === "company"
+                            ? "Company"
+                            : "Personal"}
+                        </span>
+                      </td>
+                    )}
+                    {!isPersonalMode && (
+                      <td className="whitespace-nowrap px-3 py-4 text-sm text-slate-500">
+                        <span
+                          className={`inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${getPartnerColor(
+                            ex.byWhom
+                          )}`}
+                        >
+                          {ex.byWhom}
+                        </span>
+                      </td>
+                    )}
                     <td className="whitespace-nowrap px-3 py-4 text-right text-sm font-semibold text-red-600 dark:text-red-400">
                       {formatCurrency(ex.amount)}
                     </td>

--- a/src/components/Forms/PersonalExpenseForm.tsx
+++ b/src/components/Forms/PersonalExpenseForm.tsx
@@ -1,0 +1,204 @@
+import React, { useState, useEffect, useCallback } from "react";
+import { PlusCircle, Save, AlertCircle } from "lucide-react";
+import type {
+  NewExpenseEntry,
+  Expense,
+} from "../../types";
+import { getTodayString } from "../../utils";
+import { formatCurrency } from "../../utils/format";
+import { SuccessToast } from "../common/SuccessToast";
+
+interface FormProps {
+  mode?: "add" | "edit";
+  initialData?: Expense;
+  onAddExpense?: (entry: NewExpenseEntry) => void;
+  onSave?: (entry: Expense) => void;
+}
+
+const INPUT_STYLES =
+  "w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-800 outline-none transition-colors duration-200 focus:border-green-500 focus:ring-2 focus:ring-green-500/20 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-200 dark:placeholder-slate-400 dark:focus:border-green-400 dark:focus:ring-green-400/20";
+
+const LABEL_STYLES =
+  "mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300";
+
+export const PersonalExpenseForm: React.FC<FormProps> = ({
+  mode = "add",
+  initialData,
+  onAddExpense,
+  onSave,
+}) => {
+  const [amount, setAmount] = useState("");
+  const [description, setDescription] = useState("");
+  const [date, setDate] = useState(getTodayString());
+  const [category, setCategory] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showSuccessToast, setShowSuccessToast] = useState(false);
+  const [successAmount, setSuccessAmount] = useState("");
+
+  useEffect(() => {
+    if (mode === "edit" && initialData) {
+      setAmount(String(initialData.amount));
+      setDescription(initialData.description);
+      setDate(initialData.date);
+      setCategory(initialData.category);
+    }
+  }, [mode, initialData]);
+
+  const resetForm = useCallback(() => {
+    setAmount("");
+    setDescription("");
+    setCategory("");
+    setDate(getTodayString());
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      if (!amount || !description || !date || !category) {
+        throw new Error("Please fill out all required fields.");
+      }
+
+      const expenseAmount = parseFloat(amount);
+
+      // For personal accounts, we use a fixed structure
+      // The byWhom field will be set to a default value since it's not relevant in personal mode
+      const commonData: NewExpenseEntry = {
+        amount: expenseAmount,
+        description,
+        date,
+        category,
+        type: "personal", // Personal account expenses are always "personal" type
+        byWhom: "Bukhtyar", // Default value for compatibility; not displayed in personal mode
+      };
+
+      if (mode === "edit" && onSave && initialData) {
+        onSave({ ...initialData, ...commonData });
+        // Show success toast for edit
+        setSuccessAmount(formatCurrency(expenseAmount));
+        setShowSuccessToast(true);
+      } else if (mode === "add" && onAddExpense) {
+        onAddExpense(commonData);
+        // Show success toast
+        setSuccessAmount(formatCurrency(expenseAmount));
+        setShowSuccessToast(true);
+        resetForm();
+      }
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : "An error occurred";
+      setError(errorMessage);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const isEditMode = mode === "edit";
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold text-slate-800 dark:text-slate-100">
+        {isEditMode ? "Edit Expense" : "Add New Expense"}
+      </h2>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div>
+            <label htmlFor="personal-expense-date" className={LABEL_STYLES}>
+              Date *
+            </label>
+            <input
+              type="date"
+              id="personal-expense-date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              className={INPUT_STYLES}
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="personal-expense-amount" className={LABEL_STYLES}>
+              Amount (PKR) *
+            </label>
+            <input
+              type="number"
+              id="personal-expense-amount"
+              placeholder="e.g., 5000"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              className={INPUT_STYLES}
+              required
+            />
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="personal-expense-description" className={LABEL_STYLES}>
+            Description *
+          </label>
+          <input
+            type="text"
+            id="personal-expense-description"
+            placeholder="e.g., Groceries, Rent, Utilities"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            className={INPUT_STYLES}
+            required
+          />
+        </div>
+
+        <div>
+          <label htmlFor="personal-expense-category" className={LABEL_STYLES}>
+            Category *
+          </label>
+          <input
+            type="text"
+            id="personal-expense-category"
+            placeholder="e.g., Food, Housing, Transportation"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            className={INPUT_STYLES}
+            required
+          />
+        </div>
+
+        {error && (
+          <div className="flex items-center gap-2 rounded-lg bg-red-50 px-3 py-2 text-sm font-medium text-red-700 dark:bg-red-900/20 dark:text-red-300">
+            <AlertCircle size={16} className="flex-shrink-0" />
+            <p>{error}</p>
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="flex w-full items-center justify-center gap-2 rounded-lg bg-green-600 px-4 py-2.5 font-medium text-white transition-colors duration-200 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-green-500 dark:hover:bg-green-600 dark:focus:ring-offset-slate-800"
+        >
+          {isSubmitting ? (
+            <div className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+          ) : isEditMode ? (
+            <>
+              <Save size={16} /> Save Changes
+            </>
+          ) : (
+            <>
+              <PlusCircle size={16} /> Add Expense
+            </>
+          )}
+        </button>
+      </form>
+
+      {/* Success Toast */}
+      <SuccessToast
+        isVisible={showSuccessToast}
+        onClose={() => setShowSuccessToast(false)}
+        type="expense"
+        message={isEditMode ? "Expense updated successfully!" : "Expense added successfully!"}
+        amount={successAmount}
+      />
+    </div>
+  );
+};

--- a/src/components/Forms/PersonalExpenseForm.tsx
+++ b/src/components/Forms/PersonalExpenseForm.tsx
@@ -1,9 +1,6 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { PlusCircle, Save, AlertCircle } from "lucide-react";
-import type {
-  NewExpenseEntry,
-  Expense,
-} from "../../types";
+import type { NewExpenseEntry, Expense } from "../../types";
 import { getTodayString } from "../../utils";
 import { formatCurrency } from "../../utils/format";
 import { SuccessToast } from "../common/SuccessToast";
@@ -136,7 +133,10 @@ export const PersonalExpenseForm: React.FC<FormProps> = ({
         </div>
 
         <div>
-          <label htmlFor="personal-expense-description" className={LABEL_STYLES}>
+          <label
+            htmlFor="personal-expense-description"
+            className={LABEL_STYLES}
+          >
             Description *
           </label>
           <input
@@ -196,7 +196,11 @@ export const PersonalExpenseForm: React.FC<FormProps> = ({
         isVisible={showSuccessToast}
         onClose={() => setShowSuccessToast(false)}
         type="expense"
-        message={isEditMode ? "Expense updated successfully!" : "Expense added successfully!"}
+        message={
+          isEditMode
+            ? "Expense updated successfully!"
+            : "Expense added successfully!"
+        }
         amount={successAmount}
       />
     </div>

--- a/src/components/Forms/index.tsx
+++ b/src/components/Forms/index.tsx
@@ -1,3 +1,4 @@
 export { TransactionForm } from "./TransactionForm";
 export { ExpenseForm } from "./ExpenseForm";
+export { PersonalExpenseForm } from "./PersonalExpenseForm";
 export { DonationForm } from "./DonationForm";

--- a/src/components/mobile-specific/AddEntryModal.tsx
+++ b/src/components/mobile-specific/AddEntryModal.tsx
@@ -1,9 +1,15 @@
 import { AnimatePresence, motion } from "framer-motion";
 import { X } from "lucide-react";
-import { DonationForm, ExpenseForm, TransactionForm } from "../Forms";
+import {
+  DonationForm,
+  ExpenseForm,
+  PersonalExpenseForm,
+  TransactionForm,
+} from "../Forms";
 
 import type { Financials } from "../../hooks/useFinancials";
 import type { AppHandlers } from "../../types";
+import { useBusinessInfo } from "../../hooks/useBusinessInfo";
 
 export interface AddEntryModalProps {
   isOpen: boolean;
@@ -20,6 +26,8 @@ export const AddEntryModal = ({
   financials,
   donationEnabled,
 }: AddEntryModalProps) => {
+  const { isPersonalMode } = useBusinessInfo();
+
   const tabs = [
     { key: "income", label: "Income" },
     { key: "expense", label: "Expense" },
@@ -88,12 +96,17 @@ export const AddEntryModal = ({
                     onAddTransaction={appState.handleAddTransaction}
                   />
                 )}
-                {appState.activeTab === "expense" && (
-                  <ExpenseForm
-                    onAddExpense={appState.handleAddExpense}
-                    financials={financials}
-                  />
-                )}
+                {appState.activeTab === "expense" &&
+                  (isPersonalMode ? (
+                    <PersonalExpenseForm
+                      onAddExpense={appState.handleAddExpense}
+                    />
+                  ) : (
+                    <ExpenseForm
+                      onAddExpense={appState.handleAddExpense}
+                      financials={financials}
+                    />
+                  ))}
                 {donationEnabled && appState.activeTab === "donation" && (
                   <DonationForm
                     onAddDonationPayout={appState.handleAddDonationPayout}

--- a/src/page/DesktopLayout.tsx
+++ b/src/page/DesktopLayout.tsx
@@ -9,6 +9,7 @@ import {
 import {
   DonationForm,
   ExpenseForm,
+  PersonalExpenseForm,
   TransactionForm,
 } from "../components/Forms";
 import { PartnerSummary } from "../components/PartnerSummary";
@@ -83,7 +84,9 @@ export const DesktopLayout = ({
       id: "expense" as const,
       label: "Expense",
       icon: TrendingDown,
-      component: (
+      component: isPersonalMode ? (
+        <PersonalExpenseForm onAddExpense={appState.handleAddExpense} />
+      ) : (
         <ExpenseForm
           onAddExpense={appState.handleAddExpense}
           financials={financials}


### PR DESCRIPTION
Introduces a dedicated, simplified expense form and listing for **Personal** account types while keeping **all** Partnership flows, data, and UI **unchanged** and fully backward compatible.

> Note: Account type ≠ expense type. Expense types (`personal`, `share`) apply **only** to Partnership accounts. No Partnership logic has been altered.

---

## Why

The current expense form was designed for Partnership accounts and confuses Personal users with irrelevant fields. This PR adds a lean Personal form and table to support personal-ledger tracking without touching existing Partnership behavior.

---

## What Changed

### 1) New Component — `PersonalExpenseForm.tsx`

* **Path:** `src/components/Forms/PersonalExpenseForm.tsx`
* **Purpose:** Minimal form tailored for Personal accounts.
* **Fields:** `Date`, `Amount`, `Description`, `Category`
* **Not shown:** `Expense Type`, `By Whom`, share/split/partner fields.
* **Behavior:** Defaults persisted with `type: "personal"`; `byWhom` set to a default value for compatibility (see Data section).

### 2) Forms Barrel Export

* **Path:** `src/components/Forms/index.tsx`
* **Change:** Export `PersonalExpenseForm`.

### 3) Desktop Layout

* **Path:** `src/page/DesktopLayout.tsx`
* **Change:** Conditional render based on account type (via `useBusinessInfo`):

  * **Personal:** `PersonalExpenseForm`
  * **Partnership:** existing `ExpenseForm` (unchanged)

### 4) Mobile Layout

* **Path:** `src/components/mobile-specific/AddEntryModal.tsx`
* **Change:** Same conditional logic as desktop for mobile add-entry modal.

### 5) Edit Modal

* **Path:** `src/components/EditModal.tsx`
* **Change:** Edit uses the correct form by account type:

  * **Personal:** simplified edit form
  * **Partnership:** full-featured edit form (unchanged)

### 6) Expense History Table

* **Path:** `src/components/ExpenseHistory.tsx`
* **Changes:**

  * Hide `Type` and `Spent By` columns for **Personal** accounts.
  * Show Category within description row (consistent across modes).
  * Cleaner, relevant columns in Personal mode.

---

## Behavior by Account Type

### Partnership (unchanged)

* Full expense form with `expense_type` (`personal`/`share`)
* Partner selection (“By Whom”), splits, validations, confirmations
* Balance checks (personal) and capital checks (shared)
* Full expense history columns and reporting
* All existing logic / exports preserved

### Personal (new)

* Simplified create/edit form (Date, Amount, Description, Category)
* No partner selection, no expense-type selection
* Streamlined history table focused on personal ledger tracking

---

## Data & Compatibility

* **Persistence:**

  * Personal expenses stored with `type: "personal"`.
  * `byWhom` uses a default value (`"Bukhtyar"`) to maintain compatibility with existing consumers expecting that field.
* **Schema:** No DB changes required; existing model remains valid.
* **API:** No contract changes. Partnership-only fields are not sent from Personal flows.

---

## Account Type Detection

* Uses `useBusinessInfo`:

  * `businessInfo.type === "personal"` → Personal mode
  * Otherwise (e.g., `partnership`) → Partnership mode

---

## Testing / QA Steps

1. **Personal Create:** In a Personal account, open Add Expense → verify only the 4 fields appear → save → record persists as `type: "personal"` with default `byWhom`.
2. **Personal Edit:** Edit a Personal expense → verify the same minimal fields and successful save.
3. **Personal List:** Expense History for Personal accounts hides `Type`/`Spent By`; shows Category inline; amounts and dates correct.
4. **Partnership Create/Edit:** In a Partnership account, verify the existing form (including `expense_type`, partner fields, splits) behaves exactly as before.
5. **Partnership List:** All columns and calculations unchanged.
6. **Mobile:** Repeat steps 1–5 via `AddEntryModal` on mobile layout.
7. **Import/Export:** Verify both account types produce/ingest data as before.
8. **Non-Regression:** Run existing Partnership E2E and unit tests; no diffs in snapshots for Partnership views.

---

## Acceptance Criteria

* Personal accounts use the new form for create/edit; Partnership keeps the existing form/logic.
* Personal history table excludes `Type` and `Spent By`.
* Partnership features, validations, and reports are unaffected.
* No invalid field mixing (Personal flows do not send partnership-only fields).

---

## Risk & Mitigations

* **Risk:** Cross-impact on Partnership rendering.

  * **Mitigation:** Strict gating via `useBusinessInfo.type`; no edits to existing Partnership components.
* **Risk:** Downstream code depending on `byWhom`.

  * **Mitigation:** Default `byWhom` maintained for Personal entries to preserve compatibility.

